### PR TITLE
Update confluent-snapshots URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>confluent-snapshots</id>
-            <url>https://s3-us-west-2.amazonaws.com/confluent-snapshots/</url>
+            <url>https://confluent-snapshots.public.confluent.io/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>


### PR DESCRIPTION
updates the confluent-snapshots URL, the new URL is a CloudFront endpoint and it provides automatic failover.